### PR TITLE
Fix a bug with complicated version specifications

### DIFF
--- a/lib/bundler/advise/advisory.rb
+++ b/lib/bundler/advise/advisory.rb
@@ -25,11 +25,11 @@ module Bundler::Advise
     end
 
     def unaffected_versions
-      Array(@unaffected_versions).map { |v| Gem::Requirement.create(v) }
+      Array(@unaffected_versions).map { |v| Gem::Requirement.create(v.split(",")) }
     end
 
     def patched_versions
-      Array(@patched_versions).map { |v| Gem::Requirement.create(v) }
+      Array(@patched_versions).map { |v| Gem::Requirement.create(v.split(",")) }
     end
 
     def is_affected?(gem_version)

--- a/spec/bundler/advisories_spec.rb
+++ b/spec/bundler/advisories_spec.rb
@@ -55,6 +55,6 @@ describe Advisories do
     ads.length.should == 1
     ad = ads.first
     ad.gem.should == 'bar'
-    ad.patched_versions.should == [Gem::Requirement.create('>= 1.0.2')]
+    ad.patched_versions.should == [Gem::Requirement.create('>= 1.0.2'), Gem::Requirement.create(["~> 1.1", "> 1.1.1"])]
   end
 end

--- a/spec/bundler/advisory_spec.rb
+++ b/spec/bundler/advisory_spec.rb
@@ -10,8 +10,10 @@ describe Advisory do
       ad.title.should == 'bar 1.0.1 might explode your spleen'
       ad.date.should == DateTime.parse('2015-11-18')
       ad.description.should == 'This version could, like, explode your spleen if taken internally'
-      ad.unaffected_versions.should == [Gem::Requirement.create('1.0.0')]
-      ad.patched_versions.should == [Gem::Requirement.create('>= 1.0.2')]
+      ad.unaffected_versions.should == [Gem::Requirement.create('1.0.0'),
+                                        Gem::Requirement.create([">= 2.3.5","<= 2.3.14"])]
+      ad.patched_versions.should == [Gem::Requirement.create('>= 1.0.2'),
+                                     Gem::Requirement.create(['~> 1.1', '> 1.1.1'])]
     end
 
     it 'should output back to yaml as hash' do

--- a/spec/fixture/gems/bar/bar-1_0_1.yml
+++ b/spec/fixture/gems/bar/bar-1_0_1.yml
@@ -4,7 +4,9 @@ date: 2015-11-18
 description: This version could, like, explode your spleen if taken internally
 patched_versions:
 - ">= 1.0.2"
+- "~> 1.1, > 1.1.1"
 title: bar 1.0.1 might explode your spleen
 unaffected_versions:
 - 1.0.0
+- ">= 2.3.5, <= 2.3.14"
 url: http://bar-gem-is-awesome.com


### PR DESCRIPTION
Patched versions and unaffected versions can sometimes have compound
version specifications. That is, versions that are specified like so:
`~> 4.2.5, > 4.2.5.1`. In order for these compound version
specifications to be handled correctly with bundler-advise, we need to
split them when calling `Gem:Requirement.create`, which is what this
commit does.

It also updates the test suite to handle these compound version
specifications.